### PR TITLE
fix(sana-sendoff): use cosmic latteo as theme-color

### DIFF
--- a/components/project/experimental/Page.tsx
+++ b/components/project/experimental/Page.tsx
@@ -48,7 +48,7 @@ export function ProjectPage({ guild, project, submissions }: ProjectPageProps) {
 	return (
 		<>
 			<Head
-				color={guild.color ?? '#FF3D3D'}
+				color={guild.color ?? (project.flags?.includes('sanaSendoff') ? '#FFF8E7' : '#FF3D3D')}
 				title={project.title}
 				description={project.shortDescription}
 				keywords={[project.title.toLowerCase()]}


### PR DESCRIPTION
Red `#FF3D3D`, which is default for HEF, doesn't really fit Sana. There are different possible options, one of them is Cosmic Latteo `#FFF8E7`.

Refs: https://www.astro.ljmu.ac.uk/~ikb/press/color.html

`theme-color` is widely used for embedding links, e.g. in Discord, and might be cached; so it would be a good idea to adjust all embed-related metatags before the project goes live and is widely shared.